### PR TITLE
[오희주] 상세보기 화면 및 타 사용자 화면 follow,like,report 관련 기능

### DIFF
--- a/app/src/main/java/com/onandoff/onandoff_android/data/api/feed/FeedInterface.kt
+++ b/app/src/main/java/com/onandoff/onandoff_android/data/api/feed/FeedInterface.kt
@@ -47,6 +47,11 @@ interface FeedInterface {
         @Body followRequest: FollowRequest
     ): Call<LikeFollowResponse>
 
+    @POST("/follow/test")
+    fun followStatusResponse(
+        @Body followRequest: FollowRequest
+    ): Call<LikeFollowResponse>
+
     @POST("/reports")
     suspend fun reportFeed(
         @Body reportFeedRequest: ReportFeedRequest

--- a/app/src/main/java/com/onandoff/onandoff_android/data/model/FeedData.kt
+++ b/app/src/main/java/com/onandoff/onandoff_android/data/model/FeedData.kt
@@ -99,5 +99,6 @@ data class FeedReadData(
     val feedContent: String,
     val profileImg: String,
     val createdAt: String,
-    val isLike: Boolean
+    val isLike: Boolean,
+    val likeNum : Int
 )

--- a/app/src/main/java/com/onandoff/onandoff_android/presentation/home/otheruser/OtherUserFeedListAdapter.kt
+++ b/app/src/main/java/com/onandoff/onandoff_android/presentation/home/otheruser/OtherUserFeedListAdapter.kt
@@ -11,7 +11,9 @@ import com.onandoff.onandoff_android.data.api.util.RetrofitClient
 import com.onandoff.onandoff_android.data.model.FeedResponse
 import com.onandoff.onandoff_android.data.model.FeedResponseData
 import com.onandoff.onandoff_android.data.model.FeedSimpleData
+import com.onandoff.onandoff_android.data.model.LookAroundFeedData
 import com.onandoff.onandoff_android.databinding.ItemMypageUserfeedBinding
+import com.onandoff.onandoff_android.presentation.look.BottomSheetLookAroundFeedOptionMenu
 import com.onandoff.onandoff_android.util.APIPreferences
 import com.onandoff.onandoff_android.util.SharePreference.Companion.prefs
 import retrofit2.Call
@@ -23,6 +25,7 @@ import java.time.format.DateTimeFormatter
 @SuppressLint("NotifyDataSetChanged")
 class OtherUserFeedListAdapter(private var feedList : List<FeedResponseData>) : RecyclerView.Adapter<OtherUserFeedListAdapter.OtherUserFeedListViewHolder>() {
 
+    private lateinit var itemClickListener : OnItemClickListener
     inner class OtherUserFeedListViewHolder(val binding: ItemMypageUserfeedBinding): RecyclerView.ViewHolder(binding.root){
         fun bind(write: FeedResponseData){
             binding.tvMypageRvItemPostText.text = write.feedContent
@@ -62,6 +65,10 @@ class OtherUserFeedListAdapter(private var feedList : List<FeedResponseData>) : 
 
                     })
             }
+
+            binding.ivMypageRvItemMore.setOnClickListener {
+                itemClickListener.onClick(itemView, write.feedId)
+            }
         }
     }
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OtherUserFeedListViewHolder {
@@ -75,12 +82,21 @@ class OtherUserFeedListAdapter(private var feedList : List<FeedResponseData>) : 
 
     override fun getItemCount(): Int = feedList.size
 
+
+    interface OnItemClickListener {
+        fun onClick(v: View, feedId: Int)
+    }
+
+    fun setItemClickListener(onItemClickListener: OnItemClickListener) {
+        this.itemClickListener = onItemClickListener
+    }
+
     override fun getItemViewType(position: Int): Int {
         return position
     }
 
     fun setItems(item: List<FeedResponseData>) {
-        feedList = item
+        feedList = feedList + item
         notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/com/onandoff/onandoff_android/presentation/home/posting/CategoryAdapter.kt
+++ b/app/src/main/java/com/onandoff/onandoff_android/presentation/home/posting/CategoryAdapter.kt
@@ -10,8 +10,6 @@ import com.onandoff.onandoff_android.databinding.ItemCategoryBinding
 class CategoryAdapter: RecyclerView.Adapter<CategoryAdapter.Holder>() {
 
     private val itemList: MutableList<CategoryData> = mutableListOf()
-    private lateinit var itemClickListener : OnItemClickListener
-
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder {
         val binding = ItemCategoryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return Holder(binding)
@@ -29,21 +27,8 @@ class CategoryAdapter: RecyclerView.Adapter<CategoryAdapter.Holder>() {
     inner class Holder(var binding: ItemCategoryBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(item: CategoryData) {
             binding.categoryName.text = item.categoryName
-
-            itemView.setOnClickListener {
-                itemClickListener.onClick(itemView, item.categoryId)
-            }
         }
     }
-
-    interface OnItemClickListener {
-        fun onClick(v: View, categoryId: Int)
-    }
-
-    fun setItemClickListener(onItemClickListener: OnItemClickListener) {
-        this.itemClickListener = onItemClickListener
-    }
-
     fun setItems(item: List<CategoryData>) {
         itemList.clear()
         itemList.addAll(item)

--- a/app/src/main/java/com/onandoff/onandoff_android/presentation/home/posting/PostingReadActivity.kt
+++ b/app/src/main/java/com/onandoff/onandoff_android/presentation/home/posting/PostingReadActivity.kt
@@ -94,9 +94,11 @@ class PostingReadActivity : AppCompatActivity() {
 
             if(!likeImg) {
                 binding.posting.imageLike.setImageResource(R.drawable.ic_heart_full)
+                binding.posting.textLikeCount.visibility = View.VISIBLE
 
             } else {
                 binding.posting.imageLike.setImageResource(R.drawable.ic_heart_mono)
+                binding.posting.textLikeCount.visibility = View.INVISIBLE
             }
         }
 
@@ -182,9 +184,12 @@ class PostingReadActivity : AppCompatActivity() {
                             likeImg = response.body()!!.isLike
                             if(response.body()!!.isLike) {
                                 binding.posting.imageLike.setImageResource(R.drawable.ic_heart_full)
+                                binding.posting.textLikeCount.visibility = View.VISIBLE
                             } else {
                                 binding.posting.imageLike.setImageResource(R.drawable.ic_heart_mono)
+                                binding.posting.textLikeCount.visibility = View.INVISIBLE
                             }
+                            binding.posting.textLikeCount.text = response.body()!!.likeNum.toString()
                             val hashTagList = response.body()!!.hashTagList
                             var tagText = ""
                             if(hashTagList.isNotEmpty()) {

--- a/app/src/main/java/com/onandoff/onandoff_android/presentation/home/posting/PostingReadActivity.kt
+++ b/app/src/main/java/com/onandoff/onandoff_android/presentation/home/posting/PostingReadActivity.kt
@@ -17,7 +17,10 @@ import com.onandoff.onandoff_android.data.api.util.RetrofitClient
 import com.onandoff.onandoff_android.data.model.FeedSimpleData
 import com.onandoff.onandoff_android.data.model.FeedReadData
 import com.onandoff.onandoff_android.data.model.FeedResponse
+import com.onandoff.onandoff_android.data.model.LikeFollowResponse
+import com.onandoff.onandoff_android.data.request.FollowRequest
 import com.onandoff.onandoff_android.databinding.ActivityPostingReadBinding
+import com.onandoff.onandoff_android.presentation.look.BottomSheetLookAroundFeedOptionMenu
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -27,8 +30,10 @@ class PostingReadActivity : AppCompatActivity() {
     private lateinit var binding : ActivityPostingReadBinding
     private val feedInterface : FeedInterface? = RetrofitClient.getClient()?.create(FeedInterface::class.java)
     var profileId by Delegates.notNull<Int>()
+    var otherUserId by Delegates.notNull<Int>()
     var feedId by Delegates.notNull<Int>()
     var likeImg by Delegates.notNull<Boolean>()
+    var followImg by Delegates.notNull<Boolean>()
     private lateinit var imageAdapter: PostingImageAdapter
 
 
@@ -39,8 +44,15 @@ class PostingReadActivity : AppCompatActivity() {
 
         setContentView(view)
 
-        profileId = intent.getIntExtra("profileId",0)
-        feedId = intent.getIntExtra("feedId",0)
+        profileId = intent.getIntExtra("profileId",-1)
+        otherUserId = intent.getIntExtra("otherUserId",-1)
+        feedId = intent.getIntExtra("feedId",-1)
+        if(profileId == -1 || feedId == -1) finish()
+        if (otherUserId == -1) {
+            binding.posting.imageFollow.visibility = View.GONE
+        } else {
+            binding.posting.imageFollow.visibility = View.VISIBLE
+        }
         readPost(profileId, feedId)
         init()
     }
@@ -55,21 +67,28 @@ class PostingReadActivity : AppCompatActivity() {
             finish()
         }
         binding.btnPostingReadDots.setOnClickListener {
-            val bottomPostingOptionFragment = PostingOptionFragment{
-                when(it) {
-                    1 -> {
-                        val intent = Intent(this, PostingModifyActivity::class.java)
-                        intent.putExtra("profileId", profileId)
-                        intent.putExtra("feedId", feedId)
-                        startActivity(intent)
-                    }
-                    0 -> {
-                        showDeleteDialog()
+            if(otherUserId == -1) {
+                val bottomPostingOptionFragment = PostingOptionFragment{
+                    when(it) {
+                        1 -> {
+                            val intent = Intent(this, PostingModifyActivity::class.java)
+                            intent.putExtra("profileId", profileId)
+                            intent.putExtra("feedId", feedId)
+                            startActivity(intent)
+                        }
+                        0 -> {
+                            showDeleteDialog()
+                        }
                     }
                 }
+                bottomPostingOptionFragment.show(supportFragmentManager, bottomPostingOptionFragment.tag)
+            } else {
+                val bottomSheetDialogFragment =
+                    BottomSheetLookAroundFeedOptionMenu.newInstance(feedId = feedId)
+                bottomSheetDialogFragment.show(supportFragmentManager, bottomSheetDialogFragment.tag)
             }
-            bottomPostingOptionFragment.show(supportFragmentManager, bottomPostingOptionFragment.tag)
         }
+
         binding.posting.imageLike.setOnClickListener {
             clickLike(profileId, feedId)
 
@@ -80,6 +99,42 @@ class PostingReadActivity : AppCompatActivity() {
                 binding.posting.imageLike.setImageResource(R.drawable.ic_heart_mono)
             }
         }
+
+        setupFollowStatus()
+
+        binding.posting.imageFollow.setOnClickListener {
+            clickFollow(profileId, otherUserId)
+
+            if(!followImg) {
+                binding.posting.imageFollow.setImageResource(R.drawable.ic_is_following)
+
+            } else {
+                binding.posting.imageFollow.setImageResource(R.drawable.ic_not_following)
+            }
+        }
+    }
+
+    private fun setupFollowStatus() {
+        val request = FollowRequest(profileId, otherUserId)
+        val call = feedInterface?.followStatusResponse(request)
+        call?.enqueue(object : Callback<LikeFollowResponse> {
+            override fun onResponse(
+                call: Call<LikeFollowResponse>, response: Response<LikeFollowResponse>
+            ) {
+                followImg = if (response.body()?.message == "Follow") {
+                    binding.posting.imageFollow.setImageResource(R.drawable.ic_is_following)
+                    true
+                } else {
+                    binding.posting.imageFollow.setImageResource(R.drawable.ic_not_following)
+                    false
+                }
+            }
+
+            override fun onFailure(call: Call<LikeFollowResponse>, t: Throwable) {
+                TODO("Not yet implemented")
+            }
+
+        })
     }
 
     private fun clickLike(profileId: Int, feedId: Int) {
@@ -93,6 +148,23 @@ class PostingReadActivity : AppCompatActivity() {
             }
 
             override fun onFailure(call: Call<FeedResponse>, t: Throwable) {
+                TODO("Not yet implemented")
+            }
+
+        })
+    }
+
+    private fun clickFollow(profileId: Int, otherUserId: Int) {
+        val feedSimpleData = FollowRequest(profileId, otherUserId)
+        val call = feedInterface?.followResponse(feedSimpleData)
+        call?.enqueue(object : Callback<LikeFollowResponse> {
+            override fun onResponse(call: Call<LikeFollowResponse>, response: Response<LikeFollowResponse>) {
+                if (response.body() != null) {
+                    followImg = response.body()!!.message == "Follow"
+                }
+            }
+
+            override fun onFailure(call: Call<LikeFollowResponse>, t: Throwable) {
                 TODO("Not yet implemented")
             }
 

--- a/app/src/main/res/layout/activity_posting_read.xml
+++ b/app/src/main/res/layout/activity_posting_read.xml
@@ -11,10 +11,11 @@
 
     <ImageButton
         android:id="@+id/btn_posting_read_out"
-        android:layout_width="15dp"
-        android:layout_height="15dp"
-        android:layout_marginStart="28dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:background="#00ff0000"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
         android:contentDescription="@string/btn_out"
         app:layout_constraintBottom_toBottomOf="@+id/btn_posting_read_dots"
         app:layout_constraintStart_toStartOf="parent"
@@ -24,13 +25,14 @@
 
     <ImageButton
         android:id="@+id/btn_posting_read_dots"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="21dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:background="#00ff0000"
+        android:padding="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginTop="10dp"
+        android:contentDescription="@string/btn_category"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.94"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_dots" />
 

--- a/app/src/main/res/layout/item_posting.xml
+++ b/app/src/main/res/layout/item_posting.xml
@@ -6,7 +6,18 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-<com.google.android.material.imageview.ShapeableImageView
+    <ImageView
+        android:id="@+id/image_follow"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="60dp"
+        android:visibility="gone"
+        android:contentDescription="@string/no_following_found"
+        android:src="@drawable/ic_not_following"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/text_writer" />
+
+    <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/image_profile"
         android:layout_width="42dp"
         android:layout_height="42dp"


### PR DESCRIPTION
# PR 내용
- 상세보기 화면(좋아요 개수 출력 및  follow 작동방식 오류 수정)
- 타 사용자 화면(신고하기 기능, 현재 follow 상태 확인 및 클릭버튼)
- xml image button size 48dp

# To reviewers
- otherUserFragment는 recyclerView scroll 위치를 인식하지 못하는 버그가 있습니다.
- calendar 데이터가 뜨지 않는 버그가 있습니다.
- 상세보기 화면에서 게시글이 1개 이상이면 스크롤로 넘기는 부분을 최근에 알게되어 가장 먼저 구현하고, 남은 버그들을 수정할 예정입니다.
