### PR TITLE
[오희주] 달력과 타사용자 페이지 수정

### DIFF
--- a/app/src/main/java/com/onandoff/onandoff_android/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/onandoff/onandoff_android/presentation/home/HomeFragment.kt
@@ -193,10 +193,6 @@ class HomeFragment: Fragment(), CalendarAdapter.OnMonthChangeListener, CalendarA
             }
         }
 
-        binding.ivAlarm.setOnClickListener {
-
-        }
-
         binding.ivSetting.setOnClickListener {
             mainActivity.getSupportFragmentManager()
                 .beginTransaction()
@@ -305,12 +301,6 @@ class HomeFragment: Fragment(), CalendarAdapter.OnMonthChangeListener, CalendarA
 
 
     private fun setupCalendar() {
-        val baseCalendar = BaseCalendar()
-
-        baseCalendar.initBaseCalendar {
-            onMonthChanged(it)
-        }
-
         calendarAdapter = CalendarAdapter(this)
         calendarAdapter.setItemClickListener(this)
         binding.fgCalDay.layoutManager = GridLayoutManager(context, BaseCalendar.DAYS_OF_WEEK)
@@ -321,6 +311,10 @@ class HomeFragment: Fragment(), CalendarAdapter.OnMonthChangeListener, CalendarA
         }
         binding.fgCalNext.setOnClickListener {
             calendarAdapter.changeToNextMonth()
+        }
+        binding.containerCalendar.setOnClickListener {
+            calendarAdapter.changeToNextMonth()
+            calendarAdapter.changeToPrevMonth()
         }
     }
 
@@ -412,10 +406,10 @@ class HomeFragment: Fragment(), CalendarAdapter.OnMonthChangeListener, CalendarA
 
                 when(response.code()) {
                     200 -> {
-                        val feedList = response.body()?.result
-                        Log.d("feedList", "onResponse: ${feedList?.size}")
-                        if (!feedList.isNullOrEmpty()) {
-                            calendarAdapter.setItems(feedList)
+                        val feeds = response.body()?.result
+                        Log.d("feedList", "onResponse: ${feeds?.size}")
+                        if (!feeds.isNullOrEmpty()) {
+                            calendarAdapter.setItems(feeds)
                         }
                     }
                 }

--- a/app/src/main/java/com/onandoff/onandoff_android/presentation/home/otheruser/OtherUserFeedListAdapter.kt
+++ b/app/src/main/java/com/onandoff/onandoff_android/presentation/home/otheruser/OtherUserFeedListAdapter.kt
@@ -99,4 +99,9 @@ class OtherUserFeedListAdapter(private var feedList : List<FeedResponseData>) : 
         feedList = feedList + item
         notifyDataSetChanged()
     }
+
+    fun removeItems() {
+        feedList = emptyList()
+        notifyDataSetChanged()
+    }
 }

--- a/app/src/main/java/com/onandoff/onandoff_android/presentation/home/otheruser/OtherUserFragment.kt
+++ b/app/src/main/java/com/onandoff/onandoff_android/presentation/home/otheruser/OtherUserFragment.kt
@@ -7,6 +7,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentTransaction
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -71,6 +73,9 @@ class OtherUserFragment : Fragment(), CalendarAdapter.OnMonthChangeListener,
         setupFollowStatus()
         getProfileData()
         onInitRecyclerView()
+        binding.backBtn.setOnClickListener {
+            activity?.supportFragmentManager?.popBackStack("otherUserFragment", FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/onandoff/onandoff_android/presentation/look/LookAroundFragment.kt
+++ b/app/src/main/java/com/onandoff/onandoff_android/presentation/look/LookAroundFragment.kt
@@ -536,7 +536,7 @@ class LookAroundFragment : Fragment() {
         // TODO: 해당 데이터의 상세 페이지로 이동하기
         val intent = OtherUserFragment.newInstance(feedData.feedId, feedData.profileId)
         val transaction = activity?.supportFragmentManager?.beginTransaction()
-        transaction?.add(R.id.fcv_main, intent)?.commit()
+        transaction?.add(R.id.fcv_main, intent)?.addToBackStack("otherUserFragment")?.commit()
         Log.d("abcd", "onFeedProfileClick: ")
     }
 


### PR DESCRIPTION
# PR 내용
- 타 사용자 페이지의 글 리스트에 10개 이상이면 다음 페이지 불러오는 기능 추가
- 타 사용자 페이지에서 back버튼 누르면 원래 화면으로 돌아가는 기능
- 캘린더 화면에서 데이터 못불러오는 문제 수정

# To reviewers
- 클릭시 이동하는 상세보기 화면에서 해당 일 게시글이 1개 이상이면 스크롤로 이동할 수 있다.-> 현재 화면에 띄워줘야하는 데이터와 오는 데이터가 다르고(서버와 상의 필요), 정확히 스크롤이 되는 부분이 프로필을 제외한 글의 내용 부분인지, 목록 선택 버튼을 포함한 글 전체인지 명확하지 않아서 문의 넣어놨습니다.
- 상세화면 bottom sheet로 변경하는 부분은 일단 기능적으로 있는 문제는 아니므로, 출시 후 수정하겠습니다.
- 캘린더의 경우, 오늘 하루 종일 붙잡고 수정해봤지만, 아예 캘린더 전체 코드를 다시 만드는 정도의 수정이 필요합니다. 공부를 좀 더 해야지 해결할 수 있을 것 같아요. 일단 달력을 누르면 데이터가 업데이트 되도록 설정해뒀습니다.
