### PR TITLE
[정호섭] 난독화를 위한 proguard 업데이트 및 앱 용량 축소를 위한 shrinkResources 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,10 +23,12 @@ android {
 
     buildTypes {
         debug {
+            shrinkResources false
             minifyEnabled false
             debuggable true
         }
         release {
+            shrinkResources true
             minifyEnabled true
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,10 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**
+-dontwarn org.slf4j.impl.StaticLoggerBinder

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         activity_ktx_version = "1.8.2"
         fragment_ktx_version = "1.6.2"
         retrofit_version = "2.9.0"
-        okhttp_version = "4.9.0"
+        okhttp_version = "4.11.0"
         coroutines_version = "1.7.1"
         hilt_version = "2.48.1"
         paging_version = "3.1.1"


### PR DESCRIPTION
# PR 내용
- proguard-rules.pro 업데이트
- buildTypes의 debug, release에 shrinkResources 추가
- okhttp 버전을 4.11.0으로 업데이트
